### PR TITLE
erzwinge kleinschreibung

### DIFF
--- a/var/lib/linuxmuster-client-auth/templates/etc/ldap.conf
+++ b/var/lib/linuxmuster-client-auth/templates/etc/ldap.conf
@@ -81,6 +81,7 @@ bind_timelimit 5
 
 # The user ID attribute (defaults to uid)
 #pam_login_attribute uid
+pam_login_attribute uid:caseExactMatch:
 
 # Search the root DSE for the password policy (works
 # with Netscape Directory Server)


### PR DESCRIPTION
An verschiedenen Stellen macht die Groß-und Kleinschreibung ein Problem: Man kann sich beim Linuxclient mit GRO?SCHREIBUNG anmelden, hat dann aber später bei samba oder ähnlichem Probleme.

Forumsdiskussion: http://www.linuxmuster.net/forum/forum.php?req=thread&id=446
Ticket: http://www.linuxmuster.net/flyspray/task/436
1. Lösungsansatz funktioniert bei mir jetzt 1 Jahr
